### PR TITLE
[Improvement] Add Evince koryavniks opening support

### DIFF
--- a/evince.sh
+++ b/evince.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+evince --version 2> /dev/null
+if [[ $? -ne 0 ]]; then
+    
+    echo "Evince не установлен!"
+    exit
+    
+fi
+
+sem=$1
+str_num=$2
+
+evince -i $str_num ~/gnu-koryavov/KORYAVNIKS/${sem}.djvu


### PR DESCRIPTION
# Description
[Evince](https://github.com/GNOME/evince) is a default Gnome document viewer. The `evince.sh` can be used like `okular.sh` to open Koryavnik on a specified page.