### PR TITLE
[Improvement ] Add Xreader koryavniks opening support

### DIFF
--- a/xreader.sh
+++ b/xreader.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+xreader --version 2> /dev/null
+if [[ $? -ne 0 ]]; then
+    
+    echo "Xreader не установлен!"
+    exit
+    
+fi
+
+sem=$1
+str_num=$2
+
+xreader -p $str_num ~/gnu-koryavov/KORYAVNIKS/${sem}.djvu


### PR DESCRIPTION
# Description
[Xreader](https://github.com/linuxmint/xreader) is a default LinuxMint document viewer. The `xreader.sh` can be used like `okular.sh` to open Koryavnik on the specified page