### PR TITLE
[Improvement] Add open option, replace deprecated links in config with koryavov-books repo links

### DIFF
--- a/config.conf
+++ b/config.conf
@@ -1,11 +1,11 @@
 #KORYAVNIKS
 
 KORYAVNIKS=(
-[1]=https://lib.mipt.ru/book/267518/Koryavov-VP-Metody-resheniya-zadach-v-obschem-kurse-fiziki-Mehanika.djvu
-[2]=https://lib.mipt.ru/book/265316/Koryavov-VP-Metody-resheniya-zadach-v-obschem-kurse-fiziki-Termodinamika-i-molekulyarnaya-fizika.djvu
-[3]=https://lib.mipt.ru/book/282962/Koryavov-VP-Metody-resheniya-zadach-v-obschem-kurse-fiziki-Elektrichestvo-i-magnetizm.djvu
-[4]=https://lib.mipt.ru/book/283050/Koryavov-VP-Metody-resheniya-zadach-v-obschem-kurse-fiziki-Optika.djvu
-[5]=https://lib.mipt.ru/book/283202/Koryavov-VP-Metody-resheniya-zadach-v-obschem-kurse-fiziki-Atomnaya-i-yadernaya-fizika.djvu
+[1]=https://github.com/sin-diesel/koryavov-books/raw/master/Koryavov-VP-Metody-resheniya-zadach-v-obschem-kurse-fiziki-Mehanika.djvu
+[2]=https://github.com/sin-diesel/koryavov-books/raw/master/Koryavov-VP-Metody-resheniya-zadach-v-obschem-kurse-fiziki-Termodinamika-i-molekulyarnaya-fizika.djvu
+[3]=https://github.com/sin-diesel/koryavov-books/raw/master/Koryavov-VP-Metody-resheniya-zadach-v-obschem-kurse-fiziki-Elektrichestvo-i-magnetizm.djvu
+[4]=https://github.com/sin-diesel/koryavov-books/raw/master/Koryavov-VP-Metody-resheniya-zadach-v-obschem-kurse-fiziki-Optika.djvu
+[5]=https://github.com/sin-diesel/koryavov-books/raw/master/Koryavov-VP-Metody-resheniya-zadach-v-obschem-kurse-fiziki-Atomnaya-i-yadernaya-fizika.djvu
 )
 
 #PDFVIEWER

--- a/run.sh
+++ b/run.sh
@@ -8,17 +8,11 @@ open() {
     source ~/gnu-koryavov/config.conf
 
 
-    read -p "Открыть электронный корявник? (Д/н): " ans
-        
-    if [[ $ans == "y"* || $ans == "Y"* || $ans == "д"* || $ans == "Д"* ]]; then
-
-        # if [ ! -f ~/gnu-koryavov/KORYAVNIKS/${sem}.djvu ]; then
-        #     download $sem
-        # fi
-        
-        ${pdfviewer_script} $sem $str_num
-
+    if [ ! -f ~/gnu-koryavov/KORYAVNIKS/${sem}.djvu ]; then
+        download $sem
     fi
+    
+    ${pdfviewer_script} $sem $str_num
 
 }
 
@@ -34,18 +28,22 @@ download() {
 
 
 # get input options
-while getopts ":s:n:h" opt; do
+while getopts ":s:n:o:h" opt; do
     case ${opt} in
-        s)
+        s) # -s <semester>
             arg="$OPTARG"
             echo "Выбранный семестр: $arg"
             sem=$arg
             ;;
 
-        n)  
+        n) # -n <problem-number> 
             arg="$OPTARG"
             echo "Выбранная задача: $arg"
             zad=$arg
+            ;;
+        o) # -open
+            open=true
+            echo "Электронный корявник будет открыт"
             ;;
         \?|h)
             echo "Usage: TODO"
@@ -63,7 +61,7 @@ fi
 shift $((OPTIND -1))
 
 task_regex="[[:digit:]]+\.[[:digit:]]+"
-if ! [[ $num =~ $task_regex ]]; then
+if ! [[ $zad =~ $task_regex ]]; then
     echo "Укажите номер задачи корректно!"
     exit 1
 fi
@@ -83,7 +81,9 @@ if [[ $? -eq 0 ]]; then
     str_num=$(echo $status | sed -nr "s/.*на странице №([[:digit:]]{1,4})!.*/\1/p")
     echo "Задача $zad найдена на странице №$str_num!"
     
-    # open $sem $str_num
+    if [[ $open = true ]]; then
+        open $sem $str_num
+    fi
 
 else
     echo "Задача $zad не найдена в корявнике :("

--- a/run.sh
+++ b/run.sh
@@ -42,7 +42,7 @@ while getopts ":s:n:o:h" opt; do
             zad=$arg
             ;;
         o) # -open
-            open=true
+            open="true"
             echo "Электронный корявник будет открыт"
             ;;
         \?|h)
@@ -81,7 +81,7 @@ if [[ $? -eq 0 ]]; then
     str_num=$(echo $status | sed -nr "s/.*на странице №([[:digit:]]{1,4})!.*/\1/p")
     echo "Задача $zad найдена на странице №$str_num!"
     
-    if [[ $open = true ]]; then
+    if [[ $open == "true" ]]; then
         open $sem $str_num
     fi
 


### PR DESCRIPTION
# Description
- An appropriate koryavnik will be opened via `pdfviewer` (see `config.conf`) if option `-open` is specified
- There were deprecated links to koryavniks, I replaced them with links to the [koryavov-books](https://github.com/sin-diesel/koryavov-books)
- `download` section is now uncommented